### PR TITLE
add appropriate send/sync bounds. fixes #1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@ pub struct Cache<K> {
     pages: Vec<Page<K>>,
 }
 
-unsafe impl<K> Send for Cache<K> {}
-unsafe impl<K> Sync for Cache<K> {}
+unsafe impl<K: Send> Send for Cache<K> {}
+unsafe impl<K: Sync> Sync for Cache<K> {}
 
 impl<K: Hash + Eq> Cache<K> {
     /// Create a new cache setting page size and number of pages.


### PR DESCRIPTION
Fixes #1 

This PR adds correct Send/Sync bounds to Send/Sync impls
in order to prevent incorrect usage at compile time.

Thank you for reviewing this PR :+1: 